### PR TITLE
✨ 특정 API 엔드포인트에 인증 요구 추가

### DIFF
--- a/src/main/java/site/haruhana/www/config/SecurityConfig.java
+++ b/src/main/java/site/haruhana/www/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import site.haruhana.www.config.security.handler.CustomAccessDeniedHandler;
+import site.haruhana.www.config.security.handler.CustomAuthenticationEntryPoint;
 import site.haruhana.www.config.security.JwtAuthenticationFilter;
 import site.haruhana.www.oauth.CustomOAuth2UserService;
 import site.haruhana.www.oauth.handler.OAuth2LoginFailureHandler;
@@ -20,11 +22,10 @@ import site.haruhana.www.oauth.handler.OAuth2LoginSuccessHandler;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
-
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -32,8 +33,10 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable) // Rest API 사용으로 CSRF 비활성화.
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers("/actuator/health").permitAll()
-                        .anyRequest().permitAll() // Todo: 현재 모든 요청을 허용하고 있지만, 추후 인증 관련 API가 개발되면 수정 필요.
+                        .requestMatchers("/actuator/health").permitAll() // 로드밸런서 대상그룹 Health Check를 위해 허용
+                        .requestMatchers("/api/problems/**").permitAll() // 문제 관련 API는 인증이 필수가 아님
+                        .requestMatchers("/api/submissions/**").authenticated() // 답안 제출 관련 API는 인증 필수
+                        .anyRequest().authenticated() // 그 외의 API는 인증 필수
                 )
                 .oauth2Login(oAuth2LoginConfigurer -> oAuth2LoginConfigurer
                         .userInfoEndpoint(
@@ -44,6 +47,10 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT 사용으로 세션 비활성화.
+                )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(customAuthenticationEntryPoint) // 인증되지 않은 사용자가 보호된 리소스에 접근할 때
+                        .accessDeniedHandler(customAccessDeniedHandler) // 인증된 사용자가 권한이 없는 리소스에 접근할 때
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // UsernamePasswordAuthenticationFilter 전에 JWT 필터 추가
                 .build();

--- a/src/main/java/site/haruhana/www/config/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/site/haruhana/www/config/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package site.haruhana.www.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import site.haruhana.www.dto.BaseResponse;
+
+import java.io.IOException;
+
+/**
+ * 인증된 사용자가 권한이 없는 리소스에 접근 시 처리를 담당하는 클래스
+ * <p>
+ * 인증은 되었으나 해당 리소스에 대한 접근 권한이 없는 경우 403 Forbidden 응답을 반환한다. (JSON 형식)
+ * 주로 권한이 부족한 사용자(예: 일반 USER가 ADMIN 리소스에 접근)가 접근하는 경우에 호출된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        // HTTP 응답 설정
+        response.setStatus(HttpStatus.FORBIDDEN.value()); // 상태 코드 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE); // Content-Type 설정
+
+        // 오류 응답 객체 생성
+        BaseResponse<Void> errorResponse = BaseResponse.onForbidden("접근 권한이 없습니다.");
+
+        // 응답 본문에 JSON 작성
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}

--- a/src/main/java/site/haruhana/www/config/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/site/haruhana/www/config/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package site.haruhana.www.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import site.haruhana.www.dto.BaseResponse;
+
+import java.io.IOException;
+
+/**
+ * 인증되지 않은 사용자의 보호된 리소스 접근 시 처리를 담당하는 클래스
+ * <p>
+ * 인증이 필요한 엔드포인트에 인증 없이 접근할 경우 401 Unauthorized 응답을 반환한다. (JSON 형식)
+ * 주로 토큰이 없거나 유효하지 않은 경우, 또는 인증 정보가 누락된 경우에 호출된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        // HTTP 응답 설정
+        response.setStatus(HttpStatus.UNAUTHORIZED.value()); // 상태 코드 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE); // Content-Type 설정
+
+        // 오류 응답 객체 생성
+        BaseResponse<Void> errorResponse = BaseResponse.onUnauthorized("인증이 필요합니다. 로그인 후 이용해주세요.");
+
+        // 응답 본문에 JSON 작성
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}


### PR DESCRIPTION
# 🚀 개요

`submissions` 테이블에서 `user_id`가 `NULL`로 저장되는 문제를 해결하기 위해 Spring Security 설정을 강화하고, 인증되지 않은 요청을 차단하도록 수정했습니다. 

## 🔍 변경사항

- `/api/submissions/**` 엔드포인트에 인증 요구(`authenticated()`) 설정 추가
- 인증되지 않은 요청(401)과 권한 부족 요청(403)을 처리하기 위해 `CustomAuthenticationEntryPoint`와 `CustomAccessDeniedHandler` 구현
- `/api/problems/**`는 인증 없이 접근 가능하도록 유지, 그 외 모든 요청은 인증 필수로 설정
