### PR TITLE
🚑 답안 정답 여부 컬럼 nullable 속성 변경

### DIFF
--- a/src/main/java/site/haruhana/www/entity/submission/Submission.java
+++ b/src/main/java/site/haruhana/www/entity/submission/Submission.java
@@ -63,7 +63,7 @@ public class Submission {
     /**
      * 사용자가 제출한 답안의 정답 여부
      */
-    @Column(name = "is_correct", nullable = false)
+    @Column(name = "is_correct", nullable = true)
     private Boolean isCorrect;
 
     /**


### PR DESCRIPTION
# 🚀 개요

답안의 정답 여부를 나타내는 `is_correct` 컬럼을 null 값이 허용되도록 조정했습니다.

기존에는 https://github.com/one-day-one-problem/backend/commit/e6c267dc59560e7e8d3a593f074cfb312b5bd7ab 커밋에서 `is_correct` 컬럼이 null이 될 수 없도록 설정했었습니다. 주관식과 객관식 답안이 채점된 후에는 `is_correct` 값이 null이 아니어야 한다고 판단했기 때문입니다.

하지만 메시지 큐에서 채점을 기다리는 동안에는 `is_correct` 컬럼이 null 상태임에 따라, 이전처럼 null을 허용하도록 다시 수정했습니다.

## 🔍 변경사항

- `is_correct` 필드가 null 값을 허용하도록 수정했습니다. 다만, `is_correct`가 null이 될 수 없다는 설정이 아직 main 브랜치에는 적용되지 않았으며, 이전 버전에서도 null이 가능하도록 설정되어 있어 운영 환경에는 변화가 없습니다.