### PR TITLE
🐛 잘못된 형식의 답변 제출 시 401 대신 400 으로 반환되도록 수정

### DIFF
--- a/src/main/java/site/haruhana/www/advice/GlobalExceptionHandler.java
+++ b/src/main/java/site/haruhana/www/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import site.haruhana.www.dto.BaseResponse;
+import site.haruhana.www.exception.InvalidAnswerFormatException;
 import site.haruhana.www.exception.ProblemNotFoundException;
 
 @RestControllerAdvice
@@ -16,4 +17,12 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.NOT_FOUND)
                 .body(BaseResponse.onNotFound(e.getMessage()));
     }
+
+    @ExceptionHandler(InvalidAnswerFormatException.class)
+    public ResponseEntity<BaseResponse<Void>> handleInvalidAnswerFormatException(InvalidAnswerFormatException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(BaseResponse.onBadRequest(e.getMessage()));
+    }
+
 }

--- a/src/main/java/site/haruhana/www/exception/InvalidAnswerFormatException.java
+++ b/src/main/java/site/haruhana/www/exception/InvalidAnswerFormatException.java
@@ -1,0 +1,9 @@
+package site.haruhana.www.exception;
+
+public class InvalidAnswerFormatException extends RuntimeException {
+
+    public InvalidAnswerFormatException() {
+        super("올바르지 않은 답안 형식입니다. 객관식 문제의 경우 숫자만 입력 가능합니다.");
+    }
+
+}

--- a/src/main/java/site/haruhana/www/service/SubmissionService.java
+++ b/src/main/java/site/haruhana/www/service/SubmissionService.java
@@ -11,6 +11,7 @@ import site.haruhana.www.entity.problem.ProblemType;
 import site.haruhana.www.entity.problem.choice.ProblemOption;
 import site.haruhana.www.entity.submission.Submission;
 import site.haruhana.www.entity.user.User;
+import site.haruhana.www.exception.InvalidAnswerFormatException;
 import site.haruhana.www.exception.ProblemNotFoundException;
 import site.haruhana.www.queue.SubmissionMessageQueue;
 import site.haruhana.www.queue.message.GradingData;
@@ -73,8 +74,8 @@ public class SubmissionService {
         }
 
         // 응답 생성 및 반환
-        return problem.getType() == ProblemType.MULTIPLE_CHOICE ? 
-                SubmissionResponseDto.fromMultipleChoice(submission) : 
+        return problem.getType() == ProblemType.MULTIPLE_CHOICE ?
+                SubmissionResponseDto.fromMultipleChoice(submission) :
                 SubmissionResponseDto.fromSubjective(submission);
     }
 
@@ -104,16 +105,22 @@ public class SubmissionService {
      *
      * @param submittedAnswer 제출된 답안 (쉼표로 구분된 문자열)
      * @return 옵션 ID 집합
+     * @throws InvalidAnswerFormatException 입력값이 숫자가 아닌 경우
      */
     private Set<Long> parseSubmittedAnswer(String submittedAnswer) {
         if (submittedAnswer == null || submittedAnswer.trim().isEmpty()) {
             return Collections.emptySet();
         }
 
-        return Arrays.stream(submittedAnswer.split(","))
-                .map(String::trim)
-                .map(Long::valueOf)
-                .collect(Collectors.toSet());
+        try {
+            return Arrays.stream(submittedAnswer.split(","))
+                    .map(String::trim)
+                    .map(Long::valueOf)
+                    .collect(Collectors.toSet());
+
+        } catch (NumberFormatException e) {
+            throw new InvalidAnswerFormatException();
+        }
     }
 
     /**


### PR DESCRIPTION
# 🚀 개요

잘못된 형식의 답변 제출 시 `401 인증 오류`가 발생하던 문제를 수정하여, `400 Bad Request` 응답을 반환하도록 개선했습니다.

## 🔍 변경사항

- `parseSubmittedAnswer` 메서드에서 숫자가 아닌 입력값에 대해 `InvalidAnswerFormatException`을 던지도록 수정.
- `InvalidAnswerFormatException` 발생 시 `400 Bad Request` 응답을 반환하는 예외 핸들러 추가.
- 기존 `401 인증 오류` 대신 `400 Bad Request` 응답을 반환하도록 로직 개선.