### PR TITLE
🐛 문제 답안 제출 API에 사용자 인증 정보에 대한 Null 검증 추가

### DIFF
--- a/src/main/java/site/haruhana/www/controller/SubmissionController.java
+++ b/src/main/java/site/haruhana/www/controller/SubmissionController.java
@@ -1,6 +1,7 @@
 package site.haruhana.www.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +29,7 @@ public class SubmissionController {
      */
     @PostMapping("/problems/{problemId}/submissions")
     public ResponseEntity<BaseResponse<SubmissionResponseDto>> submitAnswer(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal @NotNull User user,
             @PathVariable("problemId") Long problemId,
             @Valid @RequestBody SubmissionRequestDto requestDto
     ) {


### PR DESCRIPTION
# 🚀 개요

문제 답안 제출 API에 사용자 인증 정보에 대한 Null 검증을 추가하여, 인증되지 않은 요청이 데이터베이스에 영향을 미치지 않도록 수정하였습니다.

## 🔍 변경사항

- `SubmissionController`의 submitAnswer 메서드에서 인증되지 않은 사용자인 경우 `user`가 null이 되어 예외가 발생됩니다.