### PR TITLE
⚡ DB 인덱싱을 통한 문제 목록 API 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
@@ -72,4 +74,15 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+    
+    // 성능 테스트를 위한 메모리 설정
+    jvmArgs = [
+        '-Xmx2g',
+        '-Xms1g',
+        '-XX:+UseG1GC',
+        '-XX:MaxGCPauseMillis=200'
+    ]
+    
+    // 테스트 타임아웃 설정
+    systemProperty 'junit.jupiter.execution.timeout.default', '10m'
 }

--- a/sql/Update.sql
+++ b/sql/Update.sql
@@ -10,3 +10,66 @@ ALTER TABLE problems DROP COLUMN expected_answer_length;
  */
 
 ALTER TABLE submissions MODIFY COLUMN score DOUBLE NULL;
+
+/*
+ * v0.4.0 performance optimization - Database Indexing
+ * - 변경 사유: 문제 목록 조회 API 성능 최적화를 위한 인덱스 추가
+ * - 목표: 15초 응답 시간을 100-300ms로 단축
+ */
+
+-- ===== SUBMISSIONS 테이블 인덱스 =====
+
+-- 1. 사용자별 정답 조회 최적화 (가장 중요한 인덱스)
+-- 쿼리: SELECT DISTINCT s.problem_id FROM submissions s WHERE s.user_id = ? AND s.is_correct = 1
+CREATE INDEX idx_submissions_user_correct_problem ON submissions(user_id, is_correct, problem_id);
+
+-- 2. 문제별 사용자 제출 조회 최적화
+-- 쿼리: SELECT ... FROM submissions WHERE problem_id = ? AND user_id = ? AND is_correct = ?
+CREATE INDEX idx_submissions_problem_user_correct ON submissions(problem_id, user_id, is_correct);
+
+-- 3. 사용자별 제출 이력 조회 최적화 (시간순 정렬)
+-- 쿼리: SELECT ... FROM submissions WHERE user_id = ? ORDER BY submitted_at DESC
+CREATE INDEX idx_submissions_user_submitted_at ON submissions(user_id, submitted_at DESC);
+
+-- 4. 정답 여부별 통계 조회 최적화
+-- 쿼리: SELECT ... FROM submissions WHERE is_correct = ? ORDER BY submitted_at
+CREATE INDEX idx_submissions_correct_submitted_at ON submissions(is_correct, submitted_at DESC);
+
+-- 5. 문제별 제출 통계 조회 최적화
+-- 쿼리: SELECT ... FROM submissions WHERE problem_id = ? ORDER BY submitted_at
+CREATE INDEX idx_submissions_problem_submitted_at ON submissions(problem_id, submitted_at DESC);
+
+-- ===== PROBLEMS 테이블 인덱스 =====
+
+-- 6. 복합 필터링 조회 최적화 (category + difficulty + type)
+-- 쿼리: SELECT ... FROM problems WHERE category = ? AND difficulty = ? AND type = ?
+CREATE INDEX idx_problems_category_difficulty_type ON problems(category, difficulty, type);
+
+-- 7. 상태별 solved_count 정렬 최적화 (기본 정렬)
+-- 쿼리: SELECT ... FROM problems WHERE status = 'ACTIVE' ORDER BY solved_count DESC
+CREATE INDEX idx_problems_status_solved_count ON problems(status, solved_count DESC);
+
+-- 8. 카테고리별 최신순 정렬 최적화
+-- 쿼리: SELECT ... FROM problems WHERE category = ? ORDER BY created_at DESC
+CREATE INDEX idx_problems_category_created_at ON problems(category, created_at DESC);
+
+-- 9. 난이도별 최신순 정렬 최적화
+-- 쿼리: SELECT ... FROM problems WHERE difficulty = ? ORDER BY created_at DESC
+CREATE INDEX idx_problems_difficulty_created_at ON problems(difficulty, created_at DESC);
+
+-- 10. 타입별 최신순 정렬 최적화
+-- 쿼리: SELECT ... FROM problems WHERE type = ? ORDER BY created_at DESC
+CREATE INDEX idx_problems_type_created_at ON problems(type, created_at DESC);
+
+-- 11. solved_count 정렬 전용 인덱스 (MOST_SOLVED, LEAST_SOLVED)
+-- 쿼리: SELECT ... FROM problems ORDER BY solved_count DESC
+CREATE INDEX idx_problems_solved_count_desc ON problems(solved_count DESC);
+
+-- 12. created_at 정렬 전용 인덱스 (LATEST, OLDEST)
+-- 쿼리: SELECT ... FROM problems ORDER BY created_at DESC
+CREATE INDEX idx_problems_created_at_desc ON problems(created_at DESC);
+
+-- ===== 인덱스 통계 업데이트 =====
+-- 새로 생성된 인덱스의 통계 정보를 업데이트하여 옵티마이저가 올바른 실행 계획을 세우도록 함
+ANALYZE TABLE submissions;
+ANALYZE TABLE problems;

--- a/src/main/java/site/haruhana/www/entity/problem/Problem.java
+++ b/src/main/java/site/haruhana/www/entity/problem/Problem.java
@@ -17,7 +17,15 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "problems")
+@Table(name = "problems", indexes = {
+        @Index(name = "idx_problems_category_difficulty_type", columnList = "category, difficulty, type"),
+        @Index(name = "idx_problems_status_solved_count", columnList = "status, solved_count"),
+        @Index(name = "idx_problems_category_created_at", columnList = "category, created_at"),
+        @Index(name = "idx_problems_difficulty_created_at", columnList = "difficulty, created_at"),
+        @Index(name = "idx_problems_type_created_at", columnList = "type, created_at"),
+        @Index(name = "idx_problems_solved_count_desc", columnList = "solved_count DESC"),
+        @Index(name = "idx_problems_created_at_desc", columnList = "created_at DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Problem extends BaseTimeEntity {
 

--- a/src/main/java/site/haruhana/www/entity/submission/Submission.java
+++ b/src/main/java/site/haruhana/www/entity/submission/Submission.java
@@ -17,7 +17,13 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "submissions")
+@Table(name = "submissions", indexes = {
+        @Index(name = "idx_submissions_user_correct_problem", columnList = "user_id, is_correct, problem_id"),
+        @Index(name = "idx_submissions_problem_user_correct", columnList = "problem_id, user_id, is_correct"),
+        @Index(name = "idx_submissions_user_submitted_at", columnList = "user_id, submitted_at"),
+        @Index(name = "idx_submissions_correct_submitted_at", columnList = "is_correct, submitted_at"),
+        @Index(name = "idx_submissions_problem_submitted_at", columnList = "problem_id, submitted_at")
+})
 public class Submission {
 
     /**

--- a/src/test/java/site/haruhana/www/performance/ProblemListPerformanceTest.java
+++ b/src/test/java/site/haruhana/www/performance/ProblemListPerformanceTest.java
@@ -1,0 +1,232 @@
+package site.haruhana.www.performance;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import site.haruhana.www.controller.ProblemController;
+import site.haruhana.www.dto.BaseResponse;
+import site.haruhana.www.dto.problem.ProblemPage;
+import site.haruhana.www.dto.problem.ProblemSortType;
+import site.haruhana.www.dto.problem.ProblemSummaryDto;
+import site.haruhana.www.entity.problem.ProblemCategory;
+import site.haruhana.www.entity.problem.ProblemDifficulty;
+import site.haruhana.www.entity.problem.ProblemType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("문제 목록 조회 성능 테스트")
+class ProblemListPerformanceTest {
+
+    @Autowired
+    private ProblemController problemController;
+
+    private Random random;
+
+    private static final int TOTAL_PROBLEMS = 115021; // 실제 데이터 개수
+
+    @BeforeEach
+    void setUp() {
+        random = new Random();
+        log.info("성능 테스트 준비 완료");
+    }
+
+    @Test
+    @DisplayName("비인증 사용자 - Controller 직접 호출 - 10000회 요청")
+    @Transactional(readOnly = true)
+    void measureUnauthenticatedUserControllerPerformanceWith10000Requests() {
+        // Given
+        final int totalRequests = 10000;
+        List<Long> responseTimes = new ArrayList<>();
+
+        log.info("=== 비인증 사용자 Controller 직접 호출 성능 테스트 시작 ===");
+        log.info("총 요청 횟수: {} 회", totalRequests);
+
+        long totalStartTime = System.nanoTime();
+
+        // When & Then
+        for (int i = 0; i < totalRequests; i++) {
+            // 랜덤 파라미터 생성 (비인증 사용자용)
+            TestParams params = generateRandomTestParamsForUnauthenticated();
+
+            // 개별 요청 시간 측정 (Controller 직접 호출, 비인증 사용자)
+            long startTime = System.nanoTime();
+
+            // ProblemController 직접 호출 (사용자 정보 null로 전달)
+            BaseResponse<ProblemPage<ProblemSummaryDto>> response = problemController.getProblems(
+                    params.page,
+                    params.size,
+                    params.category,
+                    params.difficulty,
+                    params.type,
+                    params.sortType,
+                    false,  // 비인증 사용자는 미해결 문제 필터 사용 불가
+                    null    // 비인증 사용자 (AuthenticationPrincipal이 null)
+            ).getBody();
+
+            long endTime = System.nanoTime();
+            long responseTime = endTime - startTime;
+            responseTimes.add(responseTime);
+
+            // 결과 검증
+            assertThat(response).isNotNull();
+            assertThat(response.getData()).isNotNull();
+            assertThat(response.getData().getProblems()).isNotNull();
+
+            // 1000회마다 중간 진행상황 로깅
+            if ((i + 1) % 1000 == 0) {
+                double avgTimeMs = responseTimes.stream()
+                        .skip(Math.max(0, responseTimes.size() - 1000))
+                        .mapToLong(Long::longValue)
+                        .average()
+                        .orElse(0.0) / 1_000_000.0;
+
+                log.info("진행 상황: {}/{} 완료, 최근 1000회 평균 응답시간: {}ms", i + 1, totalRequests, String.format("%.2f", avgTimeMs));
+            }
+        }
+
+        long totalEndTime = System.nanoTime();
+
+        // 성능 통계 계산 및 출력
+        log.info("=== 비인증 사용자 Controller 성능 테스트 결과 ===");
+        logPerformanceStatistics(responseTimes, totalStartTime, totalEndTime, totalRequests);
+    }
+
+    /**
+     * 비인증 사용자를 위한 랜덤 테스트 파라미터 생성
+     * (미해결 문제 필터 사용 불가)
+     * 115,021개 데이터를 고려한 실제 규모 반영
+     */
+    private TestParams generateRandomTestParamsForUnauthenticated() {
+        TestParams params = new TestParams();
+
+        // 페이지 크기를 실제 UI에서 사용하는 값들로 설정 (12, 24, 36)
+        int[] pageSizes = {12, 24, 36};
+        params.size = pageSizes[random.nextInt(pageSizes.length)];
+
+        // 실제 데이터 개수에 따라 최대 페이지 번호 계산
+        int maxPage = calculateMaxPage(TOTAL_PROBLEMS, params.size);
+        params.page = random.nextInt(maxPage + 1); // 0부터 maxPage까지
+
+        // 실제 존재하는 카테고리들을 순환하며 사용
+        params.category = getRandomCategory();
+
+        // 실제 존재하는 난이도들을 순환하며 사용
+        params.difficulty = getRandomDifficulty();
+
+        // 실제 존재하는 타입들을 순환하며 사용
+        params.type = getRandomType();
+
+        // 모든 정렬 타입을 골고루 사용
+        params.sortType = getRandomSortType();
+
+        // 비인증 사용자는 미해결 문제 필터 사용 불가
+        params.onlyUnsolved = false;
+
+        // 비인증 사용자
+        params.useAuth = false;
+
+        return params;
+    }
+
+    /**
+     * 주어진 데이터 개수와 페이지 크기에 따른 최대 페이지 번호 계산
+     *
+     * @param totalData 총 데이터 개수
+     * @param pageSize  페이지 크기
+     * @return 최대 페이지 번호 (0-based)
+     */
+    private int calculateMaxPage(int totalData, int pageSize) {
+        return (totalData - 1) / pageSize; // 0-based 페이지 번호의 최대값
+    }
+
+    private ProblemCategory getRandomCategory() {
+        ProblemCategory[] categories = ProblemCategory.values();
+        return categories[random.nextInt(categories.length)];
+    }
+
+    private ProblemDifficulty getRandomDifficulty() {
+        ProblemDifficulty[] difficulties = ProblemDifficulty.values();
+        return difficulties[random.nextInt(difficulties.length)];
+    }
+
+    private ProblemType getRandomType() {
+        ProblemType[] types = ProblemType.values();
+        return types[random.nextInt(types.length)];
+    }
+
+    private ProblemSortType getRandomSortType() {
+        ProblemSortType[] sortTypes = ProblemSortType.values();
+        return sortTypes[random.nextInt(sortTypes.length)];
+    }
+
+    private void logPerformanceStatistics(List<Long> responseTimes, long totalStartTime, long totalEndTime, int totalRequests) {
+        // 응답시간 통계 계산 (nanoseconds to milliseconds)
+        double avgTimeMs = responseTimes.stream()
+                .mapToLong(Long::longValue)
+                .average()
+                .orElse(0.0) / 1_000_000.0;
+
+        double minTimeMs = responseTimes.stream()
+                .mapToLong(Long::longValue)
+                .min()
+                .orElse(0L) / 1_000_000.0;
+
+        double maxTimeMs = responseTimes.stream()
+                .mapToLong(Long::longValue)
+                .max()
+                .orElse(0L) / 1_000_000.0;
+
+        // 중간값 계산
+        List<Long> sortedTimes = responseTimes.stream().sorted().toList();
+        double medianTimeMs = sortedTimes.get(sortedTimes.size() / 2) / 1_000_000.0;
+
+        // 95 퍼센타일 계산
+        double p95TimeMs = sortedTimes.get((int) (sortedTimes.size() * 0.95)) / 1_000_000.0;
+
+        // 99 퍼센타일 계산
+        double p99TimeMs = sortedTimes.get((int) (sortedTimes.size() * 0.99)) / 1_000_000.0;
+
+        // 전체 소요시간
+        double totalTimeMs = (totalEndTime - totalStartTime) / 1_000_000.0;
+        double totalTimeSeconds = totalTimeMs / 1000.0;
+
+        // TPS (Transactions Per Second) 계산
+        double tps = totalRequests / totalTimeSeconds;
+
+        // 결과 출력
+        log.info("=== 성능 테스트 결과 ===");
+        log.info("총 요청 수: {} 회", totalRequests);
+        log.info("총 소요시간: {}ms ({}초)", String.format("%.2f", totalTimeMs), String.format("%.2f", totalTimeSeconds));
+        log.info("평균 응답시간: {}ms", String.format("%.2f", avgTimeMs));
+        log.info("중간값 응답시간: {}ms", String.format("%.2f", medianTimeMs));
+        log.info("최소 응답시간: {}ms", String.format("%.2f", minTimeMs));
+        log.info("최대 응답시간: {}ms", String.format("%.2f", maxTimeMs));
+        log.info("95 퍼센타일: {}ms", String.format("%.2f", p95TimeMs));
+        log.info("99 퍼센타일: {}ms", String.format("%.2f", p99TimeMs));
+        log.info("TPS (처리량): {} requests/sec", String.format("%.2f", tps));
+        log.info("=== 테스트 완료 ===");
+    }
+
+    private static class TestParams {
+        int page;
+        int size;
+        ProblemCategory category;
+        ProblemDifficulty difficulty;
+        ProblemType type;
+        ProblemSortType sortType;
+        boolean onlyUnsolved;
+        boolean useAuth;
+    }
+}


### PR DESCRIPTION
# 🚀 개요

DB 인덱싱을 통한 문제 목록 API의 성능을 개선하였습니다.

테스트 환경: 2vCPU 2GB
- 문제 갯수: 115,021개 (513.13MB)
  - 객관식 문제: 59,544개 => 객관식 문제 옵션: 295,445개
  - 주관식 문제: 55,477개 => 주관식 채점 기준: 231,225개

<기존>

<img width="1440" height="900" alt="스크린샷 2025-07-10 오후 9 05 26" src="https://github.com/user-attachments/assets/2fe9f9da-8b7e-41a6-a650-bff8edf9b59d" />

<DB 인덱싱 이후>

<img width="1440" height="900" alt="스크린샷 2025-07-10 오후 9 18 37" src="https://github.com/user-attachments/assets/8431af77-1489-476f-9ca2-b0eb21fe77e5" />

&nbsp;

항목 | 개선 전 (Before) | 개선 후 (After) | 개선 효과
-- | -- | -- | --
총 소요 시간 | 5930285.51ms (5930. 29초) | 232626.05ms (232.63초) | 총 소요 시간 약 25.49배 감소 => 약 25.5배 성능 향상
평균 응답 시간 | 592.93ms | 23.21ms | 평균 응답 시간 약 25.54배 감소 => 약 25.5배 성능 향상
중간값 응답 시간 | 599.25ms | 21.91ms | 중간값 응답 시간 약 27.34배 감소 => 약 27.3배 성능 향상
최소 응답 시간 | 242.56ms | 13.64ms | 최소 응답 시간 약 17.77배 감소 => 약 17.8배 성능 향상
최대 응답 시간 | 2,457.53ms | 152.24ms | 최대 응답 시간 약 16.14배 감소 => 약 16.1배 성능 향상
95 퍼센타일 | 717.08ms | 28.27ms | 95 퍼센타일 약 25.36배 감소 => 약 25.4배 성능 향상
99 퍼센타일 | 1,305.08ms | 42.57ms | 총 소요 시간 약 30.65배 감소 => 약 30.7배 성능 향상
TPS (초당 요청 처리량) | 1.69 requests/sec | 42.99 requests/sec | TPS 약 25.44배 증가 => 약 25.4배 성능 향상

## 🔍 변경사항

- DB에 인덱싱이 추가되었습니다.
